### PR TITLE
Reload And Resolve Workaround

### DIFF
--- a/examples/file_io.rs
+++ b/examples/file_io.rs
@@ -84,7 +84,7 @@ fn main() {
     println!("Reloading from Turn Save and Resolving...");
     let turn_solve_start = time::Instant::now();
     let game3 =
-        PostFlopGame::hacky_reload_and_resolve(&game2, 100, target_exploitability, true).unwrap();
+        PostFlopGame::copy_reload_and_resolve(&game2, 100, target_exploitability, true).unwrap();
     for (i, (a, b)) in game2.strategy().iter().zip(game3.strategy()).enumerate() {
         if (a - b).abs() > 0.001 {
             println!("{i}: Oh no");
@@ -118,7 +118,7 @@ fn main() {
     println!("Reloading from River Save and Resolving...");
     let river_solve_start = time::Instant::now();
     let game3 =
-        PostFlopGame::hacky_reload_and_resolve(&game2, 100, target_exploitability, true).unwrap();
+        PostFlopGame::copy_reload_and_resolve(&game2, 100, target_exploitability, true).unwrap();
 
     println!(
         "River solve: {} seconds",
@@ -130,6 +130,8 @@ fn main() {
             println!("{i}: Oh no");
         }
     }
+
+    let _ = PostFlopGame::reload_and_resolve(&mut game2, 1000, target_exploitability, true);
 
     // delete the file
     std::fs::remove_file(file_save_name).unwrap();

--- a/examples/file_io.rs
+++ b/examples/file_io.rs
@@ -77,8 +77,9 @@ fn main() {
         game2.target_memory_usage() as f64 / (1024.0 * 1024.0)
     );
 
-    // overwrite the file with the truncated game tree
-    // game tree constructed from this file cannot access information after the river deal
+    // Overwrite the file with the truncated game tree. The game tree
+    // constructed from this file cannot access information after the turn; this
+    // data will need to be recomputed via `PostFlopGame::reload_and_resolve`.
     save_data_to_file(&game2, "memo string", file_save_name, None).unwrap();
 
     println!("Reloading from Turn Save and Resolving...");
@@ -97,7 +98,7 @@ fn main() {
 
     println!("\n-----------------------------------------");
     println!("Saving [Flop Save] to {}", file_save_name);
-    // discard information after the river deal when serializing
+    // discard information after the flop deal when serializing
     // this operation does not lose any information of the game tree itself
     game2.set_target_storage_mode(BoardState::Flop).unwrap();
 
@@ -112,17 +113,17 @@ fn main() {
     );
 
     // overwrite the file with the truncated game tree
-    // game tree constructed from this file cannot access information after the river deal
-    save_data_to_file(&game2, "memo string", file_save_name, None).unwrap();
+    // game tree constructed from this file cannot access information after the flop deal
+    save_data_to_file(&game2, "This is a flop save", file_save_name, None).unwrap();
 
-    println!("Reloading from River Save and Resolving...");
-    let river_solve_start = time::Instant::now();
+    println!("Reloading from Flop Save and Resolving...");
+    let flop_solve_start = time::Instant::now();
     let game3 =
         PostFlopGame::copy_reload_and_resolve(&game2, 100, target_exploitability, true).unwrap();
 
     println!(
-        "River solve: {} seconds",
-        river_solve_start.elapsed().as_secs()
+        "\nFlop solve: {} seconds",
+        flop_solve_start.elapsed().as_secs()
     );
 
     for (i, (a, b)) in game2.strategy().iter().zip(game3.strategy()).enumerate() {

--- a/examples/file_io.rs
+++ b/examples/file_io.rs
@@ -72,9 +72,8 @@ fn main() {
     save_data_to_file(&game2, "memo string", "filename.bin", None).unwrap();
 
     println!("Reloading and Resolving...");
-    let mut game3 = PostFlopGame::hacky_reload_and_resolve(&game2, 100, 0.01, true).unwrap();
-    println!("game2[0]: {}", game2.strategy()[0]);
-    println!("game3[0]: {}", game3.strategy()[0]);
+    let game3 =
+        PostFlopGame::hacky_reload_and_resolve(&game2, 100, target_exploitability, true).unwrap();
     for (i, (a, b)) in game2.strategy().iter().zip(game3.strategy()).enumerate() {
         if (a - b).abs() > 0.001 {
             println!("{i}: Oh no");

--- a/examples/file_io.rs
+++ b/examples/file_io.rs
@@ -1,22 +1,24 @@
 use postflop_solver::*;
+use std::time;
 
 fn main() {
     // see `basic.rs` for the explanation of the following code
 
     let oop_range = "66+,A8s+,A5s-A4s,AJo+,K9s+,KQo,QTs+,JTs,96s+,85s+,75s+,65s,54s";
     let ip_range = "QQ-22,AQs-A2s,ATo+,K5s+,KJo+,Q8s+,J8s+,T7s+,96s+,86s+,75s+,64s+,53s+";
+    let file_save_name = "test_save.pfs";
 
     let card_config = CardConfig {
         range: [oop_range.parse().unwrap(), ip_range.parse().unwrap()],
         flop: flop_from_str("Td9d6h").unwrap(),
-        turn: card_from_str("Qc").unwrap(),
+        turn: NOT_DEALT, //card_from_str("Qc").unwrap(),
         river: NOT_DEALT,
     };
 
     let bet_sizes = BetSizeOptions::try_from(("60%, e, a", "2.5x")).unwrap();
 
     let tree_config = TreeConfig {
-        initial_state: BoardState::Turn,
+        initial_state: BoardState::Flop,
         starting_pot: 200,
         effective_stack: 900,
         rake_rate: 0.0,
@@ -37,22 +39,30 @@ fn main() {
 
     let max_num_iterations = 1000;
     let target_exploitability = game.tree_config().starting_pot as f32 * 0.005;
+    let full_solve_start = time::Instant::now();
     solve(&mut game, max_num_iterations, target_exploitability, true);
+
+    println!(
+        "Full solve: {} seconds",
+        full_solve_start.elapsed().as_secs()
+    );
 
     // save the solved game tree to a file
     // 4th argument is zstd compression level (1-22); requires `zstd` feature to use
-    save_data_to_file(&game, "memo string", "filename.bin", None).unwrap();
+    save_data_to_file(&game, "memo string", file_save_name, None).unwrap();
 
     // load the solved game tree from a file
     // 2nd argument is the maximum memory usage in bytes
     let (mut game2, _memo_string): (PostFlopGame, _) =
-        load_data_from_file("filename.bin", None).unwrap();
+        load_data_from_file(file_save_name, None).unwrap();
 
     // check if the loaded game tree is the same as the original one
     game.cache_normalized_weights();
     game2.cache_normalized_weights();
     assert_eq!(game.equity(0), game2.equity(0));
 
+    println!("\n-----------------------------------------");
+    println!("Saving [Turn Save] to {}", file_save_name);
     // discard information after the river deal when serializing
     // this operation does not lose any information of the game tree itself
     game2.set_target_storage_mode(BoardState::Turn).unwrap();
@@ -69,9 +79,10 @@ fn main() {
 
     // overwrite the file with the truncated game tree
     // game tree constructed from this file cannot access information after the river deal
-    save_data_to_file(&game2, "memo string", "filename.bin", None).unwrap();
+    save_data_to_file(&game2, "memo string", file_save_name, None).unwrap();
 
-    println!("Reloading and Resolving...");
+    println!("Reloading from Turn Save and Resolving...");
+    let turn_solve_start = time::Instant::now();
     let game3 =
         PostFlopGame::hacky_reload_and_resolve(&game2, 100, target_exploitability, true).unwrap();
     for (i, (a, b)) in game2.strategy().iter().zip(game3.strategy()).enumerate() {
@@ -79,27 +90,47 @@ fn main() {
             println!("{i}: Oh no");
         }
     }
+    println!(
+        "Turn solve: {} seconds",
+        turn_solve_start.elapsed().as_secs()
+    );
 
-    // game3.back_to_root();
-    // game3.cache_normalized_weights();
-    // for (a, b) in game2.equity(0).iter().zip(game3.equity(0)) {
-    //     if (a - b).abs() > 0.001 {
-    //         println!("Oh no");
-    //     }
-    // }
-    // game2.back_to_root();
-    // game2.cache_normalized_weights();
+    println!("\n-----------------------------------------");
+    println!("Saving [Flop Save] to {}", file_save_name);
+    // discard information after the river deal when serializing
+    // this operation does not lose any information of the game tree itself
+    game2.set_target_storage_mode(BoardState::Flop).unwrap();
 
-    // for (a, b) in game2
-    //     .expected_values(0)
-    //     .iter()
-    //     .zip(game3.expected_values(0))
-    // {
-    //     if (a - b).abs() > 0.001 {
-    //         println!("{} {} {}", a, b, (a - b).abs());
-    //     }
-    // }
+    // compare the memory usage for serialization
+    println!(
+        "Memory usage of the original game tree: {:.2}MB", // 11.50MB
+        game.target_memory_usage() as f64 / (1024.0 * 1024.0)
+    );
+    println!(
+        "Memory usage of the truncated game tree: {:.2}MB", // 0.79MB
+        game2.target_memory_usage() as f64 / (1024.0 * 1024.0)
+    );
+
+    // overwrite the file with the truncated game tree
+    // game tree constructed from this file cannot access information after the river deal
+    save_data_to_file(&game2, "memo string", file_save_name, None).unwrap();
+
+    println!("Reloading from River Save and Resolving...");
+    let river_solve_start = time::Instant::now();
+    let game3 =
+        PostFlopGame::hacky_reload_and_resolve(&game2, 100, target_exploitability, true).unwrap();
+
+    println!(
+        "River solve: {} seconds",
+        river_solve_start.elapsed().as_secs()
+    );
+
+    for (i, (a, b)) in game2.strategy().iter().zip(game3.strategy()).enumerate() {
+        if (a - b).abs() > 0.001 {
+            println!("{i}: Oh no");
+        }
+    }
 
     // delete the file
-    std::fs::remove_file("filename.bin").unwrap();
+    std::fs::remove_file(file_save_name).unwrap();
 }

--- a/examples/file_io.rs
+++ b/examples/file_io.rs
@@ -118,6 +118,7 @@ fn main() {
 
     println!("Reloading from Flop Save and Resolving...");
     let flop_solve_start = time::Instant::now();
+    println!("Using copy_reload_and_resolve: this results in a new game");
     let game3 =
         PostFlopGame::copy_reload_and_resolve(&game2, 100, target_exploitability, true).unwrap();
 
@@ -132,7 +133,14 @@ fn main() {
         }
     }
 
+    println!();
+    println!("Using reload_and_resolve: this overwrites the existing game");
+    let flop_solve_start = time::Instant::now();
     let _ = PostFlopGame::reload_and_resolve(&mut game2, 1000, target_exploitability, true);
+    println!(
+        "\nFlop solve: {} seconds",
+        flop_solve_start.elapsed().as_secs()
+    );
 
     // delete the file
     std::fs::remove_file(file_save_name).unwrap();

--- a/examples/file_io.rs
+++ b/examples/file_io.rs
@@ -71,6 +71,36 @@ fn main() {
     // game tree constructed from this file cannot access information after the river deal
     save_data_to_file(&game2, "memo string", "filename.bin", None).unwrap();
 
+    println!("Reloading and Resolving...");
+    let mut game3 = PostFlopGame::hacky_reload_and_resolve(&game2, 100, 0.01, true).unwrap();
+    println!("game2[0]: {}", game2.strategy()[0]);
+    println!("game3[0]: {}", game3.strategy()[0]);
+    for (i, (a, b)) in game2.strategy().iter().zip(game3.strategy()).enumerate() {
+        if (a - b).abs() > 0.001 {
+            println!("{i}: Oh no");
+        }
+    }
+
+    // game3.back_to_root();
+    // game3.cache_normalized_weights();
+    // for (a, b) in game2.equity(0).iter().zip(game3.equity(0)) {
+    //     if (a - b).abs() > 0.001 {
+    //         println!("Oh no");
+    //     }
+    // }
+    // game2.back_to_root();
+    // game2.cache_normalized_weights();
+
+    // for (a, b) in game2
+    //     .expected_values(0)
+    //     .iter()
+    //     .zip(game3.expected_values(0))
+    // {
+    //     if (a - b).abs() > 0.001 {
+    //         println!("{} {} {}", a, b, (a - b).abs());
+    //     }
+    // }
+
     // delete the file
     std::fs::remove_file("filename.bin").unwrap();
 }

--- a/examples/node_locking.rs
+++ b/examples/node_locking.rs
@@ -27,7 +27,7 @@ fn normal_node_locking() {
 
     // node locking must be performed after allocating memory and before solving
     game.play(1); // OOP all-in
-    game.lock_current_strategy(&[0.25, 0.75]); // lock IP's strategy: 25% fold, 75% call
+    game.lock_current_node(&[0.25, 0.75]); // lock IP's strategy: 25% fold, 75% call
     game.back_to_root();
 
     solve(&mut game, 1000, 0.001, false);
@@ -42,7 +42,7 @@ fn normal_node_locking() {
 
     game.allocate_memory(false);
     game.play(1);
-    game.lock_current_strategy(&[0.5, 0.5]); // lock IP's strategy: 50% fold, 50% call
+    game.lock_current_node(&[0.5, 0.5]); // lock IP's strategy: 50% fold, 50% call
     game.back_to_root();
 
     solve(&mut game, 1000, 0.001, false);
@@ -77,7 +77,7 @@ fn partial_node_locking() {
     game.allocate_memory(false);
 
     // lock OOP's strategy: only JJ is locked and the rest is not
-    game.lock_current_strategy(&[0.8, 0.0, 0.0, 0.2, 0.0, 0.0]); // JJ: 80% check, 20% all-in
+    game.lock_current_node(&[0.8, 0.0, 0.0, 0.2, 0.0, 0.0]); // JJ: 80% check, 20% all-in
 
     solve(&mut game, 1000, 0.001, false);
     game.cache_normalized_weights();

--- a/src/alloc.rs
+++ b/src/alloc.rs
@@ -29,11 +29,11 @@ struct StackAllocData {
 }
 
 thread_local! {
-    static STACK_ALLOC_DATA: RefCell<StackAllocData> = RefCell::new(StackAllocData {
+    static STACK_ALLOC_DATA: RefCell<StackAllocData> = const {RefCell::new(StackAllocData {
         index: usize::MAX,
         base: Vec::new(),
         current: Vec::new(),
-    });
+    })};
 }
 
 impl StackAllocData {

--- a/src/bunching.rs
+++ b/src/bunching.rs
@@ -175,8 +175,8 @@ fn next_combination(mask: u64) -> u64 {
 #[inline]
 fn compress_mask(mut mask: u64, flop: [Card; 3]) -> u64 {
     assert!(flop[0] < flop[1] && flop[1] < flop[2]);
-    for i in 0..3 {
-        let m = (1 << (flop[i] as usize - i)) - 1;
+    for (i, &c) in flop.iter().enumerate() {
+        let m = (1 << (c as usize - i)) - 1;
         mask = (mask & m) | ((mask >> 1) & !m);
     }
     mask
@@ -716,11 +716,15 @@ impl BunchingData {
                 let chunk_end_index = usize::min(chunk_start_index + 100, end_index);
                 let mut src_mask = index_to_mask(chunk_start_index, K);
 
-                for src_index in chunk_start_index..chunk_end_index {
+                for entry in src_table
+                    .iter()
+                    .take(chunk_end_index)
+                    .skip(chunk_start_index)
+                {
                     let mut src_mask_copy = src_mask;
                     src_mask = next_combination(src_mask);
 
-                    let freq = src_table[src_index].load();
+                    let freq = entry.load();
                     if freq == 0.0 {
                         continue;
                     }

--- a/src/bunching.rs
+++ b/src/bunching.rs
@@ -828,8 +828,8 @@ mod tests {
         ];
 
         let mut mask = 0b001111;
-        for i in 0..15 {
-            assert_eq!(mask, seq[i]);
+        for x in seq {
+            assert_eq!(mask, x);
             mask = next_combination(mask);
         }
     }

--- a/src/bunching.rs
+++ b/src/bunching.rs
@@ -145,12 +145,12 @@ pub struct BunchingData {
 #[inline]
 fn mask_to_index(mut mask: u64, k: usize) -> usize {
     let mut index = 0;
-    for i in 0..k {
+    COMB_TABLE.iter().take(k).for_each(|xs| {
         assert!(mask != 0);
         let tz = mask.trailing_zeros();
-        index += COMB_TABLE[i][tz as usize];
+        index += xs[tz as usize];
         mask &= mask - 1;
-    }
+    });
     index
 }
 

--- a/src/file.rs
+++ b/src/file.rs
@@ -11,7 +11,6 @@
 
 use crate::bunching::*;
 use crate::game::*;
-use crate::interface::*;
 use bincode::{Decode, Encode};
 use std::fs::File;
 use std::io::{BufReader, BufWriter, Read, Write};

--- a/src/file.rs
+++ b/src/file.rs
@@ -360,7 +360,7 @@ mod tests {
         let mut turn_game: PostFlopGame = load_data_from_file("tmpfile.flop", None).unwrap().0;
 
         let mut reloaded =
-            PostFlopGame::hacky_reload_and_resolve(&turn_game, 10, 0.01, false).unwrap();
+            PostFlopGame::copy_reload_and_resolve(&turn_game, 10, 0.01, false).unwrap();
     }
 
     #[test]

--- a/src/file.rs
+++ b/src/file.rs
@@ -241,7 +241,7 @@ impl FileData for PostFlopGame {
     }
 
     fn is_ready_to_save(&self) -> bool {
-        self.is_solved()
+        self.is_partially_solved()
     }
 
     fn estimated_memory_usage(&self) -> u64 {

--- a/src/game/base.rs
+++ b/src/game/base.rs
@@ -845,19 +845,15 @@ impl PostFlopGame {
         for (dst, src) in new_game.storage_ip.iter_mut().zip(&game.storage_ip) {
             *dst = *src;
         }
+        println!("Done!");
+
         // Nodelock and resolve
         for node_index in 0..game.node_arena.len() {
-            let _ = new_game.lock_node_at_index(node_index);
+            if new_game.node_arena[node_index].lock().river == NOT_DEALT {
+                let _ = new_game.lock_node_at_index(node_index);
+            }
         }
 
-        let s1 = game.strategy();
-        let s2 = new_game.strategy();
-        println!("game2[{}]: {}", game.node_index(&game.node()), s1[0]);
-        println!(
-            "game3[{}]: {}",
-            new_game.node_index(&new_game.node()),
-            s2[0]
-        );
         crate::solve(
             &mut new_game,
             max_iterations,

--- a/src/game/base.rs
+++ b/src/game/base.rs
@@ -1460,4 +1460,9 @@ impl PostFlopGame {
     pub fn get_state(&self) -> &State {
         return &self.state;
     }
+
+    #[inline]
+    pub fn is_partially_solved(&self) -> bool {
+        self.state >= State::SolvedFlop
+    }
 }

--- a/src/game/base.rs
+++ b/src/game/base.rs
@@ -854,21 +854,14 @@ impl PostFlopGame {
         target_exploitability: f32,
         print_progress: bool,
     ) -> Result<PostFlopGame, String> {
-        println!("Start hacky_reload_and_resolve");
         let card_config = game.card_config.clone();
         let action_tree = ActionTree::new(game.tree_config.clone())?;
         let target_storage_mode = game.target_storage_mode();
 
-        print!("Building new game...");
         let mut new_game = PostFlopGame::with_config(card_config, action_tree)?;
-        println!("Done!");
-
-        print!("Allocating memory...");
         new_game.allocate_memory(game.is_compression_enabled());
-        println!("Done!");
 
         // Copy data into new game
-        print!("Copying memory...");
         for (dst, src) in new_game.storage1.iter_mut().zip(&game.storage1) {
             *dst = *src;
         }
@@ -881,7 +874,6 @@ impl PostFlopGame {
         for (dst, src) in new_game.storage_ip.iter_mut().zip(&game.storage_ip) {
             *dst = *src;
         }
-        println!("Done!");
 
         if target_storage_mode == BoardState::River {
             return Ok(new_game);

--- a/src/game/base.rs
+++ b/src/game/base.rs
@@ -846,20 +846,24 @@ impl PostFlopGame {
             *dst = *src;
         }
         // Nodelock and resolve
-        // for node_index in 0..game.node_arena.len() {
-        //     let _ = new_game.lock_node_at_index(node_index);
-        // }
+        for node_index in 0..game.node_arena.len() {
+            let _ = new_game.lock_node_at_index(node_index);
+        }
 
         let s1 = game.strategy();
         let s2 = new_game.strategy();
-        println!("game2[0]: {}", s1[0]);
-        println!("game3[0]: {}", s2[0]);
-        // crate::solve(
-        //     &mut new_game,
-        //     max_iterations,
-        //     target_exploitability,
-        //     print_progress,
-        // );
+        println!("game2[{}]: {}", game.node_index(&game.node()), s1[0]);
+        println!(
+            "game3[{}]: {}",
+            new_game.node_index(&new_game.node()),
+            s2[0]
+        );
+        crate::solve(
+            &mut new_game,
+            max_iterations,
+            target_exploitability,
+            print_progress,
+        );
 
         Ok(new_game)
     }

--- a/src/game/base.rs
+++ b/src/game/base.rs
@@ -810,11 +810,23 @@ impl PostFlopGame {
         info.num_storage_ip += node.num_elements_ip as u64;
     }
 
-    pub fn reload_and_resolve(_game: &mut PostFlopGame) {
-        todo!("Not Implemented!")
+    pub fn reload_and_resolve(
+        game: &mut PostFlopGame,
+        max_iterations: u32,
+        target_exploitability: f32,
+        print_progress: bool,
+    ) -> Result<(), String> {
+        *game = PostFlopGame::copy_reload_and_resolve(
+            game,
+            max_iterations,
+            target_exploitability,
+            print_progress,
+        )?;
+        Ok(())
     }
 
-    pub fn hacky_reload_and_resolve(
+    /// copy_reload_and_resolve
+    pub fn copy_reload_and_resolve(
         game: &PostFlopGame,
         max_iterations: u32,
         target_exploitability: f32,

--- a/src/game/base.rs
+++ b/src/game/base.rs
@@ -1458,6 +1458,6 @@ impl PostFlopGame {
     }
 
     pub fn get_state(&self) -> &State {
-        return &self.state;
+        &self.state
     }
 }

--- a/src/game/base.rs
+++ b/src/game/base.rs
@@ -477,8 +477,8 @@ impl PostFlopGame {
             board_mask |= 1 << river;
         }
 
-        for player in 0..2 {
-            let (hands, weights) = range[player].get_hands_weights(board_mask);
+        for (player, r) in range.iter().enumerate() {
+            let (hands, weights) = r.get_hands_weights(board_mask);
             self.initial_weights[player] = weights;
             self.private_cards[player] = hands;
         }

--- a/src/game/base.rs
+++ b/src/game/base.rs
@@ -810,6 +810,60 @@ impl PostFlopGame {
         info.num_storage_ip += node.num_elements_ip as u64;
     }
 
+    fn reload_and_resolve(game: &mut PostFlopGame) {
+        todo!("Not Implemented!")
+    }
+
+    pub fn hacky_reload_and_resolve(
+        game: &PostFlopGame,
+        max_iterations: u32,
+        target_exploitability: f32,
+        print_progress: bool,
+    ) -> Result<PostFlopGame, String> {
+        println!("Start hacky_reload_and_resolve");
+        let card_config = game.card_config.clone();
+        let action_tree = ActionTree::new(game.tree_config.clone())?;
+        print!("Building new game...");
+        let mut new_game = PostFlopGame::with_config(card_config, action_tree)?;
+        println!("Done!");
+
+        print!("Allocating memory...");
+        new_game.allocate_memory(game.is_compression_enabled());
+        println!("Done!");
+
+        // Copy data into new game
+        print!("Copying memory...");
+        for (dst, src) in new_game.storage1.iter_mut().zip(&game.storage1) {
+            *dst = *src;
+        }
+        for (dst, src) in new_game.storage2.iter_mut().zip(&game.storage2) {
+            *dst = *src;
+        }
+        for (dst, src) in new_game.storage_chance.iter_mut().zip(&game.storage_chance) {
+            *dst = *src;
+        }
+        for (dst, src) in new_game.storage_ip.iter_mut().zip(&game.storage_ip) {
+            *dst = *src;
+        }
+        // Nodelock and resolve
+        // for node_index in 0..game.node_arena.len() {
+        //     let _ = new_game.lock_node_at_index(node_index);
+        // }
+
+        let s1 = game.strategy();
+        let s2 = new_game.strategy();
+        println!("game2[0]: {}", s1[0]);
+        println!("game3[0]: {}", s2[0]);
+        // crate::solve(
+        //     &mut new_game,
+        //     max_iterations,
+        //     target_exploitability,
+        //     print_progress,
+        // );
+
+        Ok(new_game)
+    }
+
     /// Sets the bunching effect.
     fn set_bunching_effect_internal(&mut self, bunching_data: &BunchingData) -> Result<(), String> {
         self.bunching_num_dead_cards = bunching_data.fold_ranges().len() * 2;

--- a/src/game/base.rs
+++ b/src/game/base.rs
@@ -810,7 +810,7 @@ impl PostFlopGame {
         info.num_storage_ip += node.num_elements_ip as u64;
     }
 
-    fn reload_and_resolve(game: &mut PostFlopGame) {
+    pub fn reload_and_resolve(_game: &mut PostFlopGame) {
         todo!("Not Implemented!")
     }
 

--- a/src/game/base.rs
+++ b/src/game/base.rs
@@ -2,6 +2,7 @@ use super::*;
 use crate::bunching::*;
 use crate::interface::*;
 use crate::utility::*;
+use std::collections::HashSet;
 use std::mem::{self, MaybeUninit};
 
 #[cfg(feature = "rayon")]
@@ -810,6 +811,12 @@ impl PostFlopGame {
         info.num_storage_ip += node.num_elements_ip as u64;
     }
 
+    /// reload_and_resolve
+    ///
+    /// Reload forgotten streets and resolve to target exploitability.
+    ///
+    /// Note: This currently wraps [`Self::copy_reload_and_resolve`] which is
+    /// not as memory efficient as it could be.
     pub fn reload_and_resolve(
         game: &mut PostFlopGame,
         max_iterations: u32,
@@ -826,6 +833,18 @@ impl PostFlopGame {
     }
 
     /// copy_reload_and_resolve
+    ///
+    /// Copy `game` into a new `PostFlopGame` and rebuild/resolve any forgotten
+    /// streets.
+    ///
+    /// The solver will run until either `max_iterations` iterations have passed or
+    ///
+    /// # Arguments
+    ///
+    /// * `game` - the game to copy, rebuild, and resolve
+    /// * `max_iterations` - the maximum number of iterations to run the solver for
+    /// * `target_exploitability` - target exploitability for a solution
+    /// * `print_progress` - print progress during the solve
     pub fn copy_reload_and_resolve(
         game: &PostFlopGame,
         max_iterations: u32,
@@ -872,16 +891,34 @@ impl PostFlopGame {
             BoardState::Flop => game.num_nodes_per_street[0],
         };
 
+        // We are about to node lock a bunch of nodes to resolve more
+        // efficiently, so we preserve which keys were already locked to the
+        // current strategy
+        let already_locked_nodes = game.locking_strategy.keys().collect::<HashSet<&usize>>();
         for node_index in 0..num_nodes_to_lock as usize {
             // We can't ? because this tries to lock chance nodes
             let _ = new_game.lock_node_at_index(node_index);
         }
+
         crate::solve(
             &mut new_game,
             max_iterations,
             target_exploitability,
             print_progress,
         );
+
+        // Remove node locking from resolving but retain node locking passed in
+        // with `game`. Note that we _have to maintain the invariant that a
+        // node's index is in the game's locking_strategy if and only if
+        // node.is_locked == true._ That is:
+        //
+        //      game.node_arena[node_index].is_locked <=> node_index in game.locking_strategy.keys()
+        for node_index in 0..num_nodes_to_lock as usize {
+            if !already_locked_nodes.contains(&node_index) {
+                new_game.node_arena[node_index].lock().is_locked = false;
+                new_game.locking_strategy.remove(&node_index);
+            }
+        }
 
         Ok(new_game)
     }

--- a/src/game/interpreter.rs
+++ b/src/game/interpreter.rs
@@ -863,7 +863,7 @@ impl PostFlopGame {
             normalized_strategy(node.strategy(), num_actions)
         };
 
-        let locking = self.locking_strategy(&node);
+        let locking = self.locking_strategy(node);
         apply_locking_strategy(&mut ret, locking);
 
         ret.chunks_exact_mut(num_hands).for_each(|chunk| {

--- a/src/game/interpreter.rs
+++ b/src/game/interpreter.rs
@@ -659,7 +659,7 @@ impl PostFlopGame {
     /// [`cache_normalized_weights`]: #method.cache_normalized_weights
     /// [`expected_values_detail`]: #method.expected_values_detail
     pub fn expected_values(&self, player: usize) -> Vec<f32> {
-        if self.state != State::Solved {
+        if !self.is_partially_solved() {
             panic!("Game is not solved");
         }
 
@@ -711,7 +711,7 @@ impl PostFlopGame {
     /// [`expected_values`]: #method.expected_value
     /// [`cache_normalized_weights`]: #method.cache_normalized_weights
     pub fn expected_values_detail(&self, player: usize) -> Vec<f32> {
-        if self.state != State::Solved {
+        if !self.is_partially_solved() {
             panic!("Game is not solved");
         }
 

--- a/src/game/mod.rs
+++ b/src/game/mod.rs
@@ -26,7 +26,9 @@ pub enum State {
     Uninitialized = 1,
     TreeBuilt = 2,
     MemoryAllocated = 3,
-    Solved = 4,
+    SolvedFlop = 4,
+    SolvedTurn = 5,
+    Solved = 6,
 }
 
 /// A struct representing a postflop game.
@@ -81,6 +83,7 @@ pub struct PostFlopGame {
 
     // store options
     storage_mode: BoardState,
+    // NOTE: Only used for encoding
     target_storage_mode: BoardState,
     num_nodes_per_street: [u64; 3],
     is_compression_enabled: bool,

--- a/src/game/node.rs
+++ b/src/game/node.rs
@@ -51,6 +51,7 @@ impl GameNode for PostFlopNode {
 
     #[inline]
     fn regrets(&self) -> &[f32] {
+        // TODO(Jacob): Something is causing either storage2 pointer to be off, or num_elements to be too big
         unsafe { slice::from_raw_parts(self.storage2 as *const f32, self.num_elements as usize) }
     }
 

--- a/src/game/serialization.rs
+++ b/src/game/serialization.rs
@@ -103,10 +103,10 @@ impl PostFlopGame {
 static VERSION_STR: &str = "2023-03-19";
 
 thread_local! {
-    static PTR_BASE: Cell<[*const u8; 2]> = Cell::new([ptr::null(); 2]);
-    static CHANCE_BASE: Cell<*const u8> = Cell::new(ptr::null());
-    static PTR_BASE_MUT: Cell<[*mut u8; 3]> = Cell::new([ptr::null_mut(); 3]);
-    static CHANCE_BASE_MUT: Cell<*mut u8> = Cell::new(ptr::null_mut());
+    static PTR_BASE: Cell<[*const u8; 2]> = const {Cell::new([ptr::null(); 2])};
+    static CHANCE_BASE: Cell<*const u8> = const {Cell::new(ptr::null())};
+    static PTR_BASE_MUT: Cell<[*mut u8; 3]> = const {Cell::new([ptr::null_mut(); 3])};
+    static CHANCE_BASE_MUT: Cell<*mut u8> = const {Cell::new(ptr::null_mut())};
 }
 
 impl Encode for PostFlopGame {

--- a/src/game/tests.rs
+++ b/src/game/tests.rs
@@ -869,7 +869,7 @@ fn node_locking() {
 
     game.allocate_memory(false);
     game.play(1); // all-in
-    game.lock_current_strategy(&[0.25, 0.75]); // 25% fold, 75% call
+    game.lock_current_node(&[0.25, 0.75]); // 25% fold, 75% call
     game.back_to_root();
 
     solve(&mut game, 1000, 0.0, false);
@@ -889,7 +889,7 @@ fn node_locking() {
 
     game.allocate_memory(false);
     game.play(1); // all-in
-    game.lock_current_strategy(&[0.5, 0.5]); // 50% fold, 50% call
+    game.lock_current_node(&[0.5, 0.5]); // 50% fold, 50% call
     game.back_to_root();
 
     solve(&mut game, 1000, 0.0, false);
@@ -929,7 +929,7 @@ fn node_locking_partial() {
     let mut game = PostFlopGame::with_config(card_config, action_tree).unwrap();
 
     game.allocate_memory(false);
-    game.lock_current_strategy(&[0.8, 0.0, 0.0, 0.2, 0.0, 0.0]); // JJ -> 80% check, 20% all-in
+    game.lock_current_node(&[0.8, 0.0, 0.0, 0.2, 0.0, 0.0]); // JJ -> 80% check, 20% all-in
 
     solve(&mut game, 1000, 0.0, false);
     game.cache_normalized_weights();
@@ -970,7 +970,7 @@ fn node_locking_isomorphism() {
 
     game.allocate_memory(false);
     game.apply_history(&[0, 0, 15, 0, 0, 14]); // Turn: Spades, River: Hearts
-    game.lock_current_strategy(&[0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0]); // AhKh -> check
+    game.lock_current_node(&[0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0]); // AhKh -> check
 
     finalize(&mut game);
 

--- a/src/mutex_like.rs
+++ b/src/mutex_like.rs
@@ -68,7 +68,7 @@ impl<T: ?Sized> MutexLike<T> {
     }
 }
 
-impl<T: ?Sized + Default> Default for MutexLike<T> {
+impl<T: Default> Default for MutexLike<T> {
     #[inline]
     fn default() -> Self {
         Self::new(Default::default())

--- a/src/range.rs
+++ b/src/range.rs
@@ -990,6 +990,7 @@ impl FromStr for Range {
     }
 }
 
+#[allow(clippy::to_string_trait_impl)]
 impl ToString for Range {
     #[inline]
     fn to_string(&self) -> String {

--- a/src/solver.rs
+++ b/src/solver.rs
@@ -192,9 +192,10 @@ fn solve_recursive<T: Game>(
     //
     // Rows are obtained using operations from `sliceop` (e.g., `sliceop::row_mut()`).
     //
-    // `cfv_actions` will be written to by recursive calls to `solve_recursive`.
+    // `cfv_actions_hands` will be written to by recursive calls to `solve_recursive`.
     #[cfg(feature = "custom-alloc")]
-    let cfv_actions = MutexLike::new(Vec::with_capacity_in(num_actions * num_hands, StackAlloc));
+    let cfv_actions_hands =
+        MutexLike::new(Vec::with_capacity_in(num_actions * num_hands, StackAlloc));
     #[cfg(not(feature = "custom-alloc"))]
     let cfv_actions_hands = MutexLike::new(Vec::with_capacity(num_actions * num_hands));
 

--- a/src/solver.rs
+++ b/src/solver.rs
@@ -58,6 +58,19 @@ pub fn solve<T: Game>(
     }
 
     let mut root = game.root();
+
+    // Run solve_recursive once to initialize uninitialized strat memory
+    for player in 0..2 {
+        let mut result = Vec::with_capacity(game.num_private_hands(player));
+        solve_recursive(
+            result.spare_capacity_mut(),
+            game,
+            &mut root,
+            player,
+            game.initial_weights(player ^ 1),
+            &DiscountParams::new(0),
+        );
+    }
     let mut exploitability = compute_exploitability(game);
 
     if print_progress {
@@ -66,7 +79,7 @@ pub fn solve<T: Game>(
         io::stdout().flush().unwrap();
     }
 
-    for t in 0..max_num_iterations {
+    for t in 1..max_num_iterations {
         if exploitability <= target_exploitability {
             break;
         }
@@ -86,7 +99,7 @@ pub fn solve<T: Game>(
             );
         }
 
-        if (t + 1) % 10 == 0 || t + 1 == max_num_iterations {
+        if t % 10 == 0 || t + 1 == max_num_iterations {
             exploitability = compute_exploitability(game);
         }
 


### PR DESCRIPTION
This is a workaround for not being able to reload a tree in the way we'd like. In this PR we reload a tree by
1. loading a game from disk
2. creating a new game from the first game's configuration (with all nodes allocated)
3. copying the memory from the loaded game into the new game (e.g., cf_values, strategies, etc)
4. locking the copied nodes and resolving.

This is a bit memory inefficient, but actually isn't much less efficient than the original version.

In the future the correct way is to probably serialize a file into an archive that can be read from disk as individual components. For instance, the ability to read just the configuration, or just the strategy, or just the cf_values, possibly for individual streets, etc.