### PR TITLE
Refactor bet_size.rs for issue 16

### DIFF
--- a/src/action_tree.rs
+++ b/src/action_tree.rs
@@ -631,7 +631,7 @@ impl ActionTree {
             actions.push(Action::Check);
 
             // bet
-            for &bet_size in &bet_options[player as usize].bet {
+            for &bet_size in bet_options[player as usize].bets() {
                 match bet_size {
                     BetSize::PotRelative(ratio) => {
                         let amount = (pot as f64 * ratio).round() as i32;
@@ -664,7 +664,7 @@ impl ActionTree {
 
             if !info.allin_flag {
                 // raise
-                for &bet_size in &bet_options[player as usize].raise {
+                for &bet_size in bet_options[player as usize].raises() {
                     match bet_size {
                         BetSize::PotRelative(ratio) => {
                             let amount = prev_amount + (pot as f64 * ratio).round() as i32;

--- a/src/action_tree.rs
+++ b/src/action_tree.rs
@@ -599,7 +599,7 @@ impl ActionTree {
             actions.push(Action::Check);
 
             // donk bet
-            for &donk_size in &donk_options.as_ref().unwrap().donk {
+            for &donk_size in donk_options.as_ref().unwrap().donks() {
                 match donk_size {
                     BetSize::PotRelative(ratio) => {
                         let amount = (pot as f64 * ratio).round() as i32;

--- a/src/bet_size.rs
+++ b/src/bet_size.rs
@@ -54,7 +54,7 @@ pub struct BetSizeOptions {
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "bincode", derive(Decode, Encode))]
 pub struct DonkSizeOptions {
-    donk: Vec<BetSize>,
+    donks: Vec<BetSize>,
 }
 
 /// Bet size specification.
@@ -168,7 +168,7 @@ impl TryFrom<(&str, &str)> for BetSizeOptions {
 
 impl DonkSizeOptions {
     pub fn donks(&self) -> &[BetSize] {
-        &self.donk
+        &self.donks
     }
 }
 
@@ -194,7 +194,7 @@ impl TryFrom<&str> for DonkSizeOptions {
         donk.sort_unstable_by(|l, r| l.partial_cmp(r).unwrap());
 
         Ok(DonkSizeOptions {
-            donk: BetSizeOptions::as_valid_bets(donk)?,
+            donks: BetSizeOptions::as_valid_bets(donk)?,
         })
     }
 }
@@ -380,13 +380,13 @@ mod tests {
             (
                 "40%, 70%",
                 DonkSizeOptions {
-                    donk: vec![PotRelative(0.4), PotRelative(0.7)],
+                    donks: vec![PotRelative(0.4), PotRelative(0.7)],
                 },
             ),
             (
                 "50c, e, a,",
                 DonkSizeOptions {
-                    donk: vec![Additive(50, 0), Geometric(0, f64::INFINITY), AllIn],
+                    donks: vec![Additive(50, 0), Geometric(0, f64::INFINITY), AllIn],
                 },
             ),
         ];

--- a/src/bet_size.rs
+++ b/src/bet_size.rs
@@ -329,15 +329,15 @@ mod tests {
             assert_eq!(bet_size_from_str(s), Ok(expected));
         }
 
-        // let error_tests = [
-        //     "", "0", "1.23", "%", "+42%", "-30%", "x", "0x", "1x", "c", "12.3c", "10c10", "42cr",
-        //     "c3r", "0c0r", "123c101r", "1c2r3", "12c3.4r", "0e", "2.7e", "101e", "3e7", "E%",
-        //     "1e2e3", "bet", "1a", "a1",
-        // ];
+        let error_tests = [
+            "", "0", "1.23", "%", "+42%", "-30%", "x", "0x", "1x", "c", "12.3c", "10c10", "42cr",
+            "c3r", "0c0r", "123c101r", "1c2r3", "12c3.4r", "0e", "2.7e", "101e", "3e7", "E%",
+            "1e2e3", "bet", "1a", "a1",
+        ];
 
-        // for s in error_tests {
-        //     assert!(bet_size_from_str(s, true).is_err());
-        // }
+        for s in error_tests {
+            assert!(bet_size_from_str(s).is_err());
+        }
     }
 
     #[test]

--- a/src/bet_size.rs
+++ b/src/bet_size.rs
@@ -54,7 +54,7 @@ pub struct BetSizeOptions {
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "bincode", derive(Decode, Encode))]
 pub struct DonkSizeOptions {
-    pub donk: Vec<BetSize>,
+    donk: Vec<BetSize>,
 }
 
 /// Bet size specification.
@@ -163,6 +163,12 @@ impl TryFrom<(&str, &str)> for BetSizeOptions {
         raise.sort_unstable_by(|l, r| l.partial_cmp(r).unwrap());
 
         Self::try_from_sizes(bet, raise)
+    }
+}
+
+impl DonkSizeOptions {
+    pub fn donks(&self) -> &[BetSize] {
+        &self.donk
     }
 }
 

--- a/src/bet_size.rs
+++ b/src/bet_size.rs
@@ -158,8 +158,6 @@ impl TryFrom<(&str, &str)> for BetSizeOptions {
         for raise_size in raise_sizes {
             raise.push(bet_size_from_str(raise_size)?);
         }
-        // Check for ill-formed bet sizes. This includes
-        // - bet sizes with relative amounts (e.g., "3x")
 
         bet.sort_unstable_by(|l, r| l.partial_cmp(r).unwrap());
         raise.sort_unstable_by(|l, r| l.partial_cmp(r).unwrap());

--- a/src/bet_size.rs
+++ b/src/bet_size.rs
@@ -42,10 +42,10 @@ use serde::{Deserialize, Serialize};
 #[cfg_attr(feature = "bincode", derive(Decode, Encode))]
 pub struct BetSizeOptions {
     /// Bet size options for first bet.
-    bet: Vec<BetSize>,
+    bets: Vec<BetSize>,
 
     /// Bet size options for raise.
-    raise: Vec<BetSize>,
+    raises: Vec<BetSize>,
 }
 
 /// Bet size options for the donk bets.
@@ -91,8 +91,8 @@ impl BetSizeOptions {
     /// - `bets` contains an `BetSize::Additive(_, cap)` with non-zero `cap`
     pub fn try_from_sizes(bets: Vec<BetSize>, raises: Vec<BetSize>) -> Result<Self, String> {
         Ok(BetSizeOptions {
-            bet: BetSizeOptions::as_valid_bets(bets)?,
-            raise: raises,
+            bets: BetSizeOptions::as_valid_bets(bets)?,
+            raises,
         })
     }
 
@@ -122,11 +122,11 @@ impl BetSizeOptions {
     }
 
     pub fn bets(&self) -> &[BetSize] {
-        &self.bet
+        &self.bets
     }
 
     pub fn raises(&self) -> &[BetSize] {
-        &self.raise
+        &self.raises
     }
 }
 

--- a/src/game/base.rs
+++ b/src/game/base.rs
@@ -1488,7 +1488,9 @@ impl PostFlopGame {
         Ok(json_config)
     }
 
-    pub fn game_from_configs_json(configs_json: serde_json::Value) -> Result<PostFlopGame, String> {
+    pub fn game_from_configs_json(
+        configs_json: &serde_json::Value,
+    ) -> Result<PostFlopGame, String> {
         let map = configs_json.as_object().ok_or({
             "Config JSON must be a JSON object with keys \"tree_config\" and \"card_config\""
         })?;
@@ -1499,9 +1501,9 @@ impl PostFlopGame {
             .get("card_config")
             .ok_or("Config JSON must contain key \"card_config\"")?;
         let tree_config: TreeConfig = serde_json::from_value(tree_config.clone())
-            .map_err(|_| "Error deserializing tree_config")?;
+            .map_err(|e| format!("Error deserializing tree_config: {:?}", e))?;
         let card_config: CardConfig = serde_json::from_value(card_config.clone())
-            .map_err(|_| "Error deserializing card_config")?;
+            .map_err(|e| format!("Error deserializing card_config: {:?}", e))?;
         let action_tree = ActionTree::new(tree_config)?;
         PostFlopGame::with_config(card_config, action_tree)
     }

--- a/src/range.rs
+++ b/src/range.rs
@@ -993,6 +993,8 @@ impl<'de> Deserialize<'de> for Range {
     {
         struct RangeVisitor;
 
+        // A workaround in a clippy bug
+        #[allow(clippy::needless_lifetimes)]
         impl<'de> Visitor<'de> for RangeVisitor {
             type Value = Range;
 


### PR DESCRIPTION
This is a PR to address #16 

This PR addresses points in issue #16:

- Move is_raise related checks from BetSize to BetSizeOptions
- Make BetSizeOptions fields non-public
- Rename BetSizeOptions fields (pluralize)

Additionally, this PR implements some serialization/deserialization (which probably belongs in parent PR but I'm lazy), and implements `try_from_sizes` and `as_valid_bets` that moves logic about valid bet sizes (versus raise sizes) out of `BetSize`