### PR TITLE
Update bincode to 2.0.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/bkushigian/postflop-solver"
 license = "AGPL-3.0-or-later"
 
 [dependencies]
-bincode = { version = "2.0.0-rc.3", optional = true }
+bincode = { version = "2.0.1", optional = true }
 once_cell = "1.18.0"
 rayon = { version = "1.8.0", optional = true }
 regex = "1.9.6"

--- a/src/file.rs
+++ b/src/file.rs
@@ -27,7 +27,7 @@ pub enum DataType {
 }
 
 /// A trait for data that can be saved into a file.
-pub trait FileData: Decode + Encode {
+pub trait FileData: Decode<()> + Encode {
     #[doc(hidden)]
     fn data_type() -> DataType;
     #[doc(hidden)]
@@ -139,7 +139,10 @@ pub fn save_data_to_file<T: FileData, P: AsRef<Path>>(
     save_data_into_std_write(data, memo, &mut writer, compression_level)
 }
 
-fn decode_from_std_read<D: Decode, R: Read>(reader: &mut R, err_msg: &str) -> Result<D, String> {
+fn decode_from_std_read<D: Decode<()>, R: Read>(
+    reader: &mut R,
+    err_msg: &str,
+) -> Result<D, String> {
     bincode::decode_from_std_read(reader, bincode::config::standard())
         .map_err(|e| format!("{}: {}", err_msg, e))
 }

--- a/src/game/serialization.rs
+++ b/src/game/serialization.rs
@@ -174,8 +174,8 @@ impl Encode for PostFlopGame {
     }
 }
 
-impl Decode for PostFlopGame {
-    fn decode<D: Decoder>(decoder: &mut D) -> Result<Self, DecodeError> {
+impl<Context> Decode<Context> for PostFlopGame {
+    fn decode<D: Decoder<Context = Context>>(decoder: &mut D) -> Result<Self, DecodeError> {
         // version check
         let version = String::decode(decoder)?;
         if version != VERSION_STR {
@@ -292,8 +292,8 @@ impl Encode for PostFlopNode {
     }
 }
 
-impl Decode for PostFlopNode {
-    fn decode<D: Decoder>(decoder: &mut D) -> Result<Self, DecodeError> {
+impl<Context> Decode<Context> for PostFlopNode {
+    fn decode<D: Decoder<Context = Context>>(decoder: &mut D) -> Result<Self, DecodeError> {
         // node instance
         let mut node = Self {
             prev_action: Decode::decode(decoder)?,

--- a/src/mutex_like.rs
+++ b/src/mutex_like.rs
@@ -3,10 +3,10 @@ use std::ops::{Deref, DerefMut};
 
 #[cfg(feature = "bincode")]
 use bincode::{
+    BorrowDecode, Decode, Encode,
     de::{BorrowDecoder, Decoder},
     enc::Encoder,
     error::{DecodeError, EncodeError},
-    BorrowDecode, Decode, Encode,
 };
 
 /// Mutex-like wrapper, but it actually does not perform any locking.
@@ -99,17 +99,19 @@ impl<T: Encode> Encode for MutexLike<T> {
 }
 
 #[cfg(feature = "bincode")]
-impl<T: Decode> Decode for MutexLike<T> {
+impl<Context, T: Decode<Context>> Decode<Context> for MutexLike<T> {
     #[inline]
-    fn decode<D: Decoder>(decoder: &mut D) -> Result<Self, DecodeError> {
+    fn decode<D: Decoder<Context = Context>>(decoder: &mut D) -> Result<Self, DecodeError> {
         Ok(Self::new(T::decode(decoder)?))
     }
 }
 
 #[cfg(feature = "bincode")]
-impl<'de, T: BorrowDecode<'de>> BorrowDecode<'de> for MutexLike<T> {
+impl<'de, Context, T: BorrowDecode<'de, Context>> BorrowDecode<'de, Context> for MutexLike<T> {
     #[inline]
-    fn borrow_decode<D: BorrowDecoder<'de>>(decoder: &mut D) -> Result<Self, DecodeError> {
+    fn borrow_decode<D: BorrowDecoder<'de, Context = Context>>(
+        decoder: &mut D,
+    ) -> Result<Self, DecodeError> {
         Ok(Self::new(T::borrow_decode(decoder)?))
     }
 }


### PR DESCRIPTION
The 2.0.1 version of bincode added a `Context` parameter to the `Decode` trait, so this repository currently fails to compile.  This patch fixes the issue.

An alternative to this patch is to pin `bincode` and `bincode_derive` at `version = "=2.0.0-rc.3"`.